### PR TITLE
Adds the ability to load an existing compressed recording to a player instance.

### DIFF
--- a/main/playback/leap.playback-0.2.1.js
+++ b/main/playback/leap.playback-0.2.1.js
@@ -1277,6 +1277,24 @@ Recording.prototype = {
       callback.call(this, responseData.frames);
     }
 
+  },
+
+  loadCompressedRecording: function(compressedData, callback) {
+    var decompressedData = this.decompress(compressedData);
+    decompressedData = JSON.parse(decompressedData);
+    if (decompressedData.metadata.formatVersion == 2) {
+      decompressedData.frames = this.unPackFrameData(decompressedData.frames);
+    }
+
+    this.metadata = decompressedData.metadata;
+
+    console.log('Recording loaded:', this.metadata);
+
+    this.loading = false;
+
+    if (callback) {
+      callback.call(this, decompressedData.frames);
+    }
   }
 
 };
@@ -1610,7 +1628,7 @@ Recording.prototype = {
 
 
     // Accepts a hash with any of
-    // URL, recording, metadata
+    // URL, recording, metadata, compressedRecording
     // once loaded, the recording is immediately activated
     setRecording: function (options) {
       var player = this;
@@ -1671,6 +1689,10 @@ Recording.prototype = {
           player.controller.emit('playback.ajax:complete', player, this);
         });
 
+      } else if (options.compressedRecording) {
+        this.recording.loadCompressedRecording(options.compressedRecording, function(frames){
+          loadComplete.call(this, frames);
+        });
       }
 
 


### PR DESCRIPTION
Sometimes it is convenient to handle the loading of compressed gesture data from a datastore in a way that is different than the provided XHR method. So, I am suggesting this method which allows the user to add a new recording to an existing player, avoiding the need to instantiate a new player when loading a new recording.
